### PR TITLE
Add basic UI skeleton

### DIFF
--- a/FamilyPlanPro/FamilyPlanProApp.swift
+++ b/FamilyPlanPro/FamilyPlanProApp.swift
@@ -30,7 +30,7 @@ struct FamilyPlanProApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            MainTabView()
         }
         .modelContainer(sharedModelContainer)
     }

--- a/FamilyPlanPro/Views/FinalizedView.swift
+++ b/FamilyPlanPro/Views/FinalizedView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct FinalizedView: View {
+    var body: some View {
+        Text("Finalized Mode")
+            .navigationTitle("Finalized")
+    }
+}
+
+#Preview {
+    FinalizedView()
+}

--- a/FamilyPlanPro/Views/MainTabView.swift
+++ b/FamilyPlanPro/Views/MainTabView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            WeeklyPlannerContainerView()
+                .tabItem {
+                    Label("Planner", systemImage: "calendar")
+                }
+        }
+    }
+}
+
+#Preview {
+    MainTabView()
+        .modelContainer(for: Family.self, inMemory: true)
+}

--- a/FamilyPlanPro/Views/ReviewView.swift
+++ b/FamilyPlanPro/Views/ReviewView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct ReviewView: View {
+    var body: some View {
+        Text("Review Mode")
+            .navigationTitle("Review")
+    }
+}
+
+#Preview {
+    ReviewView()
+}

--- a/FamilyPlanPro/Views/SuggestionView.swift
+++ b/FamilyPlanPro/Views/SuggestionView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct SuggestionView: View {
+    var body: some View {
+        Text("Suggestion Mode")
+            .navigationTitle("Suggestions")
+    }
+}
+
+#Preview {
+    SuggestionView()
+}

--- a/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
+++ b/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+import SwiftData
+
+struct WeeklyPlannerContainerView: View {
+    @Environment(\.modelContext) private var context
+    @Query(sort: [SortDescriptor(\.startDate, order: .reverse)]) private var plans: [WeeklyPlan]
+
+    private var currentPlan: WeeklyPlan? {
+        let calendar = Calendar.current
+        return plans.first { calendar.isDate($0.startDate, equalTo: Date(), toGranularity: .weekOfYear) }
+    }
+
+    var body: some View {
+        Group {
+            if let plan = currentPlan {
+                Text("Current plan starting \(plan.startDate, format: Date.FormatStyle(date: .numeric, time: .omitted))")
+            } else {
+                Text("Start New Week")
+            }
+        }
+        .navigationTitle("Weekly Planner")
+    }
+}
+
+#Preview {
+    WeeklyPlannerContainerView()
+        .modelContainer(for: [Family.self, WeeklyPlan.self], inMemory: true)
+}


### PR DESCRIPTION
## Summary
- create MainTabView to host tabs
- add WeeklyPlannerContainerView with minimal current-plan logic
- add placeholder SuggestionView, ReviewView, and FinalizedView
- show MainTabView on app launch

## Testing
- `swiftc -parse FamilyPlanPro/Views/MainTabView.swift FamilyPlanPro/Views/WeeklyPlannerContainerView.swift FamilyPlanPro/Views/SuggestionView.swift FamilyPlanPro/Views/ReviewView.swift FamilyPlanPro/Views/FinalizedView.swift FamilyPlanPro/FamilyPlanProApp.swift FamilyPlanPro/ContentView.swift FamilyPlanPro/DataManager.swift FamilyPlanPro/FamilyDetailView.swift FamilyPlanPro/Item.swift FamilyPlanPro/Models.swift`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685c6050f0a0832da5d460a83f05593b