### PR TITLE
Fix compile issues in WeeklyPlannerContainerView

### DIFF
--- a/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
+++ b/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
@@ -3,7 +3,7 @@ import SwiftData
 
 struct WeeklyPlannerContainerView: View {
     @Environment(\.modelContext) private var context
-    @Query(sort: [SortDescriptor(\.startDate, order: .reverse)]) private var plans: [WeeklyPlan]
+    @Query(sort: [SortDescriptor(\WeeklyPlan.startDate, order: .reverse)]) private var plans: [WeeklyPlan]
 
     private var currentPlan: WeeklyPlan? {
         let calendar = Calendar.current


### PR DESCRIPTION
## Summary
- fix sort descriptor key path in `WeeklyPlannerContainerView` so SwiftData can compile

## Testing
- `swiftc -parse FamilyPlanPro/Views/WeeklyPlannerContainerView.swift`
- `swiftc -parse FamilyPlanPro/Views/MainTabView.swift`
- `for f in FamilyPlanPro/Views/*.swift; do swiftc -parse $f; done`

------
https://chatgpt.com/codex/tasks/task_e_685c6bffd984832dbd761fcbe6dd882c