### PR TITLE
Implement suggestion mode meal entry

### DIFF
--- a/FamilyPlanPro/DataManager.swift
+++ b/FamilyPlanPro/DataManager.swift
@@ -26,7 +26,7 @@ final class DataManager {
 
     // MARK: - Plan
     func createWeeklyPlan(startDate: Date, for family: Family) -> WeeklyPlan {
-        let plan = WeeklyPlan(startDate: startDate, family: family)
+        let plan = WeeklyPlan(startDate: startDate, status: .suggestionMode, family: family)
         family.plans.append(plan)
         context.insert(plan)
         return plan
@@ -39,8 +39,8 @@ final class DataManager {
         return slot
     }
 
-    func addSuggestion(title: String, to slot: MealSlot) -> MealSuggestion {
-        let suggestion = MealSuggestion(title: title, slot: slot)
+    func addSuggestion(title: String, user: User? = nil, to slot: MealSlot) -> MealSuggestion {
+        let suggestion = MealSuggestion(title: title, user: user, slot: slot)
         slot.suggestions.append(suggestion)
         context.insert(suggestion)
         return suggestion
@@ -61,7 +61,7 @@ func createDummyData(context: ModelContext) {
 
     let plan = manager.createWeeklyPlan(startDate: .now, for: family)
     let mondayBreakfast = manager.addMealSlot(date: .now, type: .breakfast, to: plan)
-    _ = manager.addSuggestion(title: "Pancakes", to: mondayBreakfast)
+    _ = manager.addSuggestion(title: "Pancakes", user: family.users.first, to: mondayBreakfast)
 
     try? manager.save()
 }

--- a/FamilyPlanPro/Models.swift
+++ b/FamilyPlanPro/Models.swift
@@ -25,12 +25,20 @@ final class User {
 
 @Model
 final class WeeklyPlan {
+    enum Status: String, Codable {
+        case suggestionMode
+        case reviewMode
+        case finalized
+    }
+
     var startDate: Date
+    var status: Status
     weak var family: Family?
     @Relationship(deleteRule: .cascade) var slots: [MealSlot] = []
 
-    init(startDate: Date, family: Family? = nil) {
+    init(startDate: Date, status: Status = .suggestionMode, family: Family? = nil) {
         self.startDate = startDate
+        self.status = status
         self.family = family
     }
 }
@@ -56,10 +64,12 @@ final class MealSlot {
 @Model
 final class MealSuggestion {
     var title: String
+    weak var user: User?
     weak var slot: MealSlot?
 
-    init(title: String, slot: MealSlot? = nil) {
+    init(title: String, user: User? = nil, slot: MealSlot? = nil) {
         self.title = title
+        self.user = user
         self.slot = slot
     }
 }

--- a/FamilyPlanPro/Views/MealSlotEntryView.swift
+++ b/FamilyPlanPro/Views/MealSlotEntryView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import SwiftData
+import Observation
+
+struct MealSlotEntryView: View {
+    @Environment(\.modelContext) private var context
+    @Bindable var slot: MealSlot
+    var users: [User]
+
+    @State private var title: String = ""
+    @State private var selectedUser: User?
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("\(slot.date, format: Date.FormatStyle(date: .numeric, time: .omitted)) \(slot.mealType.rawValue.capitalized)")
+                .font(.headline)
+            TextField("Meal name", text: $title)
+                .textFieldStyle(.roundedBorder)
+            Picker("Responsible", selection: $selectedUser) {
+                Text("Unassigned").tag(Optional<User>(nil))
+                ForEach(users) { user in
+                    Text(user.name).tag(Optional(user))
+                }
+            }
+            .pickerStyle(.menu)
+            Button("Add Suggestion") {
+                guard !title.isEmpty else { return }
+                let manager = DataManager(context: context)
+                _ = manager.addSuggestion(title: title, user: selectedUser, to: slot)
+                try? context.save()
+                title = ""
+                selectedUser = nil
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding(.vertical)
+    }
+}
+
+#Preview {
+    let container = try! ModelContainer(for: [Family.self, WeeklyPlan.self, MealSlot.self, MealSuggestion.self], inMemory: true)
+    let manager = DataManager(context: container.mainContext)
+    let family = manager.createFamily(name: "Preview")
+    _ = manager.addUser(name: "Alice", to: family)
+    let plan = manager.createWeeklyPlan(startDate: .now, for: family)
+    let slot = manager.addMealSlot(date: .now, type: .breakfast, to: plan)
+    try? container.mainContext.save()
+
+    return MealSlotEntryView(slot: slot, users: family.users)
+        .modelContainer(container)
+}

--- a/FamilyPlanPro/Views/SuggestionView.swift
+++ b/FamilyPlanPro/Views/SuggestionView.swift
@@ -1,12 +1,38 @@
 import SwiftUI
+import SwiftData
+import Observation
 
 struct SuggestionView: View {
+    @Environment(\.modelContext) private var context
+    @Bindable var plan: WeeklyPlan
+
     var body: some View {
-        Text("Suggestion Mode")
-            .navigationTitle("Suggestions")
+        List {
+            ForEach(plan.slots) { slot in
+                MealSlotEntryView(slot: slot, users: plan.family?.users ?? [])
+            }
+        }
+        .navigationTitle("Suggestions")
+        .toolbar {
+            Button("Submit for Review") {
+                plan.status = .reviewMode
+                try? context.save()
+            }
+        }
     }
 }
 
 #Preview {
-    SuggestionView()
+    let container = try! ModelContainer(for: [Family.self, WeeklyPlan.self, MealSlot.self, MealSuggestion.self], inMemory: true)
+    let manager = DataManager(context: container.mainContext)
+    let family = manager.createFamily(name: "Preview")
+    _ = manager.addUser(name: "Alice", to: family)
+    let plan = manager.createWeeklyPlan(startDate: .now, for: family)
+    _ = manager.addMealSlot(date: .now, type: .breakfast, to: plan)
+    try? container.mainContext.save()
+
+    return NavigationStack {
+        SuggestionView(plan: plan)
+    }
+    .modelContainer(container)
 }

--- a/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
+++ b/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
@@ -13,7 +13,14 @@ struct WeeklyPlannerContainerView: View {
     var body: some View {
         Group {
             if let plan = currentPlan {
-                Text("Current plan starting \(plan.startDate, format: Date.FormatStyle(date: .numeric, time: .omitted))")
+                switch plan.status {
+                case .suggestionMode:
+                    SuggestionView(plan: plan)
+                case .reviewMode:
+                    ReviewView()
+                case .finalized:
+                    FinalizedView()
+                }
             } else {
                 Text("Start New Week")
             }


### PR DESCRIPTION
## Summary
- allow entering meal suggestions for each meal slot
- track weekly plan status and meal suggestion owner in the data models
- provide a suggestion entry view and update the suggestion screen
- wire planner container to show suggestion/review/finalized views

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685c6da3c1ec832d83bac6fd50b63cb6