### PR TITLE
Fix preview return in SuggestionView

### DIFF
--- a/FamilyPlanPro/Views/SuggestionView.swift
+++ b/FamilyPlanPro/Views/SuggestionView.swift
@@ -31,7 +31,7 @@ struct SuggestionView: View {
     _ = manager.addMealSlot(date: .now, type: .breakfast, to: plan)
     try? container.mainContext.save()
 
-    return NavigationStack {
+    NavigationStack {
         SuggestionView(plan: plan)
     }
     .modelContainer(container)


### PR DESCRIPTION
## Summary
- fix build error in SuggestionView preview by removing explicit `return`

## Testing
- `swift test -c debug` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685c6fc8fb9c832dac5479cd569e9f8d