### PR TITLE
Add review workflow state machine

### DIFF
--- a/FamilyPlanPro/Models.swift
+++ b/FamilyPlanPro/Models.swift
@@ -28,17 +28,23 @@ final class WeeklyPlan {
     enum Status: String, Codable {
         case suggestionMode
         case reviewMode
+        case conflict
         case finalized
     }
 
     var startDate: Date
     var status: Status
+    var lastModifiedByUserID: String?
     weak var family: Family?
     @Relationship(deleteRule: .cascade) var slots: [MealSlot] = []
 
-    init(startDate: Date, status: Status = .suggestionMode, family: Family? = nil) {
+    init(startDate: Date,
+         status: Status = .suggestionMode,
+         lastModifiedByUserID: String? = nil,
+         family: Family? = nil) {
         self.startDate = startDate
         self.status = status
+        self.lastModifiedByUserID = lastModifiedByUserID
         self.family = family
     }
 }
@@ -52,7 +58,8 @@ final class MealSlot {
     var date: Date
     var mealType: MealType
     weak var plan: WeeklyPlan?
-    @Relationship(deleteRule: .cascade) var suggestions: [MealSuggestion] = []
+    @Relationship(deleteRule: .cascade) var finalizedSuggestion: MealSuggestion?
+    @Relationship(deleteRule: .cascade) var pendingSuggestion: MealSuggestion?
 
     init(date: Date, mealType: MealType, plan: WeeklyPlan? = nil) {
         self.date = date

--- a/FamilyPlanPro/Views/MealSlotEntryView.swift
+++ b/FamilyPlanPro/Views/MealSlotEntryView.swift
@@ -26,7 +26,7 @@ struct MealSlotEntryView: View {
             Button("Add Suggestion") {
                 guard !title.isEmpty else { return }
                 let manager = DataManager(context: context)
-                _ = manager.addSuggestion(title: title, user: selectedUser, to: slot)
+                _ = manager.setPendingSuggestion(title: title, user: selectedUser, for: slot)
                 try? context.save()
                 title = ""
                 selectedUser = nil

--- a/FamilyPlanPro/Views/ReviewView.swift
+++ b/FamilyPlanPro/Views/ReviewView.swift
@@ -1,14 +1,61 @@
 import SwiftUI
 
 struct ReviewView: View {
+    @Environment(\.modelContext) private var context
+    @Bindable var plan: WeeklyPlan
+
     var body: some View {
-        Text("Review Mode")
-            .navigationTitle("Review")
+        List {
+            ForEach(plan.slots) { slot in
+                if let pending = slot.pendingSuggestion {
+                    VStack(alignment: .leading) {
+                        Text("\(slot.date, format: Date.FormatStyle(date: .numeric, time: .omitted)) \(slot.mealType.rawValue.capitalized)")
+                            .font(.headline)
+                        Text(pending.title)
+                        HStack {
+                            Button("Accept") {
+                                let manager = DataManager(context: context)
+                                manager.acceptPendingSuggestion(in: slot)
+                                manager.finalizeIfPossible(plan)
+                                try? context.save()
+                            }
+                            .buttonStyle(.bordered)
+                            Button("Reject") {
+                                let manager = DataManager(context: context)
+                                _ = manager.rejectPendingSuggestion(in: slot, newTitle: pending.title, by: plan.family?.users.last)
+                                plan.lastModifiedByUserID = plan.family?.users.last?.name
+                                try? context.save()
+                            }
+                            .buttonStyle(.borderedProminent)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Review")
     }
 }
 
 struct ReviewView_Previews: PreviewProvider {
     static var previews: some View {
-        ReviewView()
+        let schema = Schema([
+            Family.self,
+            WeeklyPlan.self,
+            MealSlot.self,
+            MealSuggestion.self,
+        ])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: schema, configurations: [config])
+        let manager = DataManager(context: container.mainContext)
+        let family = manager.createFamily(name: "Preview")
+        let userA = manager.addUser(name: "Alice", to: family)
+        _ = manager.addUser(name: "Bob", to: family)
+        let plan = manager.createWeeklyPlan(startDate: .now, for: family)
+        let slot = manager.addMealSlot(date: .now, type: .breakfast, to: plan)
+        _ = manager.setPendingSuggestion(title: "Eggs", user: userA, for: slot)
+        try? container.mainContext.save()
+
+        return ReviewView(plan: plan)
+            .modelContainer(container)
     }
 }

--- a/FamilyPlanPro/Views/SuggestionView.swift
+++ b/FamilyPlanPro/Views/SuggestionView.swift
@@ -15,8 +15,11 @@ struct SuggestionView: View {
         .navigationTitle("Suggestions")
         .toolbar {
             Button("Submit for Review") {
-                plan.status = .reviewMode
-                try? context.save()
+                if let user = plan.family?.users.first { // naive current user
+                    let manager = DataManager(context: context)
+                    manager.submitPlanForReview(plan, by: user)
+                    try? context.save()
+                }
             }
         }
     }

--- a/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
+++ b/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
@@ -17,7 +17,9 @@ struct WeeklyPlannerContainerView: View {
                 case .suggestionMode:
                     SuggestionView(plan: plan)
                 case .reviewMode:
-                    ReviewView()
+                    ReviewView(plan: plan)
+                case .conflict:
+                    ReviewView(plan: plan) // simplified
                 case .finalized:
                     FinalizedView()
                 }
@@ -32,6 +34,6 @@ struct WeeklyPlannerContainerView: View {
 struct WeeklyPlannerContainerView_Previews: PreviewProvider {
     static var previews: some View {
         WeeklyPlannerContainerView()
-            .modelContainer(for: [Family.self, WeeklyPlan.self], inMemory: true)
+            .modelContainer(for: [Family.self, WeeklyPlan.self, MealSlot.self, MealSuggestion.self], inMemory: true)
     }
 }

--- a/FamilyPlanProTests/WorkflowTests.swift
+++ b/FamilyPlanProTests/WorkflowTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+import SwiftData
+@testable import FamilyPlanPro
+
+final class WorkflowTests: XCTestCase {
+    func testStateTransitions() throws {
+        let schema = Schema([
+            Family.self,
+            User.self,
+            WeeklyPlan.self,
+            MealSlot.self,
+            MealSuggestion.self,
+        ])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        let manager = DataManager(context: container.mainContext)
+        let family = manager.createFamily(name: "Test")
+        let userA = manager.addUser(name: "Alice", to: family)
+        _ = manager.addUser(name: "Bob", to: family)
+        let plan = manager.createWeeklyPlan(startDate: .now, for: family)
+        let slot = manager.addMealSlot(date: .now, type: .breakfast, to: plan)
+        _ = manager.setPendingSuggestion(title: "Toast", user: userA, for: slot)
+        try manager.save()
+
+        XCTAssertEqual(plan.status, .suggestionMode)
+        manager.submitPlanForReview(plan, by: userA)
+        XCTAssertEqual(plan.status, .reviewMode)
+        XCTAssertEqual(plan.lastModifiedByUserID, userA.name)
+
+        manager.acceptPendingSuggestion(in: slot)
+        manager.finalizeIfPossible(plan)
+        XCTAssertEqual(plan.status, .finalized)
+    }
+}

--- a/FamilyPlanProUITests/FamilyPlanProUITests.swift
+++ b/FamilyPlanProUITests/FamilyPlanProUITests.swift
@@ -23,12 +23,10 @@ final class FamilyPlanProUITests: XCTestCase {
     }
 
     @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
+    func testPlannerDisplaysSuggestionView() throws {
         let app = XCUIApplication()
         app.launch()
-
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        XCTAssertTrue(app.navigationBars["Suggestions"].exists)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- expand models to support review, conflict and finalized states
- allow meal suggestions to be pending or finalized
- add DataManager helpers for review flow
- show review actions in `ReviewView`
- pass plan binding through `WeeklyPlannerContainerView`
- include workflow test and simple UI test

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme FamilyPlanPro -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cdc1b92f0832d9db379c7201028d0