### PR TITLE
Ensure phase 3 state machine complete

### DIFF
--- a/FamilyPlanPro/DataManager.swift
+++ b/FamilyPlanPro/DataManager.swift
@@ -53,9 +53,19 @@ final class DataManager {
         }
     }
 
-    func rejectPendingSuggestion(in slot: MealSlot, newTitle: String, by user: User?) -> MealSuggestion {
+    func rejectPendingSuggestion(in slot: MealSlot,
+                                 newTitle: String,
+                                 by user: User?,
+                                 in plan: WeeklyPlan) -> MealSuggestion {
+        if let lastUserID = plan.lastModifiedByUserID,
+           let rejectingUser = user,
+           lastUserID != rejectingUser.name {
+            plan.status = .conflict
+        }
+
         let suggestion = MealSuggestion(title: newTitle, user: user, slot: slot)
         slot.pendingSuggestion = suggestion
+        plan.lastModifiedByUserID = user?.name
         context.insert(suggestion)
         return suggestion
     }

--- a/FamilyPlanPro/FamilyPlanProApp.swift
+++ b/FamilyPlanPro/FamilyPlanProApp.swift
@@ -31,7 +31,40 @@ struct FamilyPlanProApp: App {
     var body: some Scene {
         WindowGroup {
             MainTabView()
+                .onAppear {
+                    if let statusString = ProcessInfo.processInfo.environment["UITEST_STATUS"],
+                       let status = WeeklyPlan.Status(rawValue: statusString) {
+                        seedData(for: status)
+                    }
+                }
         }
         .modelContainer(sharedModelContainer)
+    }
+
+    private func seedData(for status: WeeklyPlan.Status) {
+        let manager = DataManager(context: sharedModelContainer.mainContext)
+        let family = manager.createFamily(name: "UITest")
+        let userA = manager.addUser(name: "Alice", to: family)
+        let userB = manager.addUser(name: "Bob", to: family)
+        let plan = manager.createWeeklyPlan(startDate: .now, for: family)
+        let slot = manager.addMealSlot(date: .now, type: .breakfast, to: plan)
+        _ = manager.setPendingSuggestion(title: "Test", user: userA, for: slot)
+
+        switch status {
+        case .reviewMode:
+            manager.submitPlanForReview(plan, by: userA)
+        case .finalized:
+            manager.submitPlanForReview(plan, by: userA)
+            manager.acceptPendingSuggestion(in: slot)
+            manager.finalizeIfPossible(plan)
+        case .conflict:
+            manager.submitPlanForReview(plan, by: userA)
+            _ = manager.rejectPendingSuggestion(in: slot, newTitle: "Alt", by: userB, in: plan)
+            _ = manager.rejectPendingSuggestion(in: slot, newTitle: "Alt2", by: userA, in: plan)
+        case .suggestionMode:
+            break
+        }
+
+        try? manager.save()
     }
 }

--- a/FamilyPlanPro/Views/ReviewView.swift
+++ b/FamilyPlanPro/Views/ReviewView.swift
@@ -24,8 +24,10 @@ struct ReviewView: View {
                             .buttonStyle(.bordered)
                             Button("Reject") {
                                 let manager = DataManager(context: context)
-                                _ = manager.rejectPendingSuggestion(in: slot, newTitle: pending.title, by: plan.family?.users.last)
-                                plan.lastModifiedByUserID = plan.family?.users.last?.name
+                                _ = manager.rejectPendingSuggestion(in: slot,
+                                                                   newTitle: pending.title,
+                                                                   by: plan.family?.users.last,
+                                                                   in: plan)
                                 try? context.save()
                             }
                             .buttonStyle(.borderedProminent)

--- a/FamilyPlanProTests/WorkflowTests.swift
+++ b/FamilyPlanProTests/WorkflowTests.swift
@@ -31,4 +31,58 @@ final class WorkflowTests: XCTestCase {
         manager.finalizeIfPossible(plan)
         XCTAssertEqual(plan.status, .finalized)
     }
+
+    func testCounterReviewKeepsReviewMode() throws {
+        let schema = Schema([
+            Family.self,
+            User.self,
+            WeeklyPlan.self,
+            MealSlot.self,
+            MealSuggestion.self,
+        ])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        let manager = DataManager(context: container.mainContext)
+        let family = manager.createFamily(name: "Test")
+        let userA = manager.addUser(name: "Alice", to: family)
+        let userB = manager.addUser(name: "Bob", to: family)
+        let plan = manager.createWeeklyPlan(startDate: .now, for: family)
+        let slot = manager.addMealSlot(date: .now, type: .breakfast, to: plan)
+        _ = manager.setPendingSuggestion(title: "Toast", user: userA, for: slot)
+        try manager.save()
+
+        manager.submitPlanForReview(plan, by: userA)
+        _ = manager.rejectPendingSuggestion(in: slot, newTitle: "Bagel", by: userB, in: plan)
+
+        XCTAssertEqual(plan.status, .reviewMode)
+        XCTAssertEqual(plan.lastModifiedByUserID, userB.name)
+    }
+
+    func testConflictOnSecondRejection() throws {
+        let schema = Schema([
+            Family.self,
+            User.self,
+            WeeklyPlan.self,
+            MealSlot.self,
+            MealSuggestion.self,
+        ])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        let manager = DataManager(context: container.mainContext)
+        let family = manager.createFamily(name: "Test")
+        let userA = manager.addUser(name: "Alice", to: family)
+        let userB = manager.addUser(name: "Bob", to: family)
+        let plan = manager.createWeeklyPlan(startDate: .now, for: family)
+        let slot = manager.addMealSlot(date: .now, type: .breakfast, to: plan)
+        _ = manager.setPendingSuggestion(title: "Toast", user: userA, for: slot)
+        try manager.save()
+
+        manager.submitPlanForReview(plan, by: userA)
+        _ = manager.rejectPendingSuggestion(in: slot, newTitle: "Bagel", by: userB, in: plan)
+
+        _ = manager.rejectPendingSuggestion(in: slot, newTitle: "Cereal", by: userA, in: plan)
+
+        XCTAssertEqual(plan.status, .conflict)
+        XCTAssertEqual(plan.lastModifiedByUserID, userA.name)
+    }
 }

--- a/FamilyPlanProUITests/FamilyPlanProUITests.swift
+++ b/FamilyPlanProUITests/FamilyPlanProUITests.swift
@@ -30,6 +30,22 @@ final class FamilyPlanProUITests: XCTestCase {
     }
 
     @MainActor
+    func testPlannerDisplaysReviewView() throws {
+        let app = XCUIApplication()
+        app.launchEnvironment["UITEST_STATUS"] = "reviewMode"
+        app.launch()
+        XCTAssertTrue(app.navigationBars["Review"].exists)
+    }
+
+    @MainActor
+    func testPlannerDisplaysFinalizedView() throws {
+        let app = XCUIApplication()
+        app.launchEnvironment["UITEST_STATUS"] = "finalized"
+        app.launch()
+        XCTAssertTrue(app.navigationBars["Finalized"].exists)
+    }
+
+    @MainActor
     func testLaunchPerformance() throws {
         // This measures how long it takes to launch your application.
         measure(metrics: [XCTApplicationLaunchMetric()]) {


### PR DESCRIPTION
## Summary
- add conflict escalation logic in DataManager
- wire ReviewView rejection through new method
- allow app to seed sample data for UI tests
- expand unit tests to cover counter‑review and conflict
- add UI tests for review and finalized states

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685ce23b1ef8832db5fbcdd0d8ddc9ae