### PR TITLE
Create week plan automatically

### DIFF
--- a/FamilyPlanPro/DataManager.swift
+++ b/FamilyPlanPro/DataManager.swift
@@ -39,6 +39,21 @@ final class DataManager {
         return slot
     }
 
+    /// Creates a new weekly plan for the current week (Sunday-Saturday)
+    /// and pre-populates meal slots for each day and meal type.
+    func createCurrentWeekPlan(for family: Family) -> WeeklyPlan {
+        let start = Calendar.current.startOfWeek(for: .now)
+        let plan = createWeeklyPlan(startDate: start, for: family)
+        let calendar = Calendar.current
+        for dayOffset in 0..<7 {
+            let date = calendar.date(byAdding: .day, value: dayOffset, to: start)!
+            for meal in MealSlot.MealType.allCases {
+                _ = addMealSlot(date: date, type: meal, to: plan)
+            }
+        }
+        return plan
+    }
+
     func setPendingSuggestion(title: String, user: User? = nil, for slot: MealSlot) -> MealSuggestion {
         let suggestion = MealSuggestion(title: title, user: user, slot: slot)
         slot.pendingSuggestion = suggestion

--- a/FamilyPlanPro/DateExtensions.swift
+++ b/FamilyPlanPro/DateExtensions.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension Calendar {
+    /// Returns the start of the week for the given date, forcing Sunday as the first day.
+    func startOfWeek(for date: Date) -> Date {
+        var calendar = self
+        calendar.firstWeekday = 1 // Sunday
+        if let interval = calendar.dateInterval(of: .weekOfYear, for: date) {
+            return interval.start
+        }
+        return calendar.startOfDay(for: date)
+    }
+}

--- a/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
+++ b/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
@@ -4,6 +4,7 @@ import SwiftData
 struct WeeklyPlannerContainerView: View {
     @Environment(\.modelContext) private var context
     @Query(sort: [SortDescriptor(\WeeklyPlan.startDate, order: .reverse)]) private var plans: [WeeklyPlan]
+    @Query private var families: [Family]
 
     private var currentPlan: WeeklyPlan? {
         let calendar = Calendar.current
@@ -24,10 +25,18 @@ struct WeeklyPlannerContainerView: View {
                     FinalizedView()
                 }
             } else {
-                Text("Start New Week")
+                ProgressView()
             }
         }
         .navigationTitle("Weekly Planner")
+        .onAppear(perform: createWeekIfNeeded)
+    }
+
+    private func createWeekIfNeeded() {
+        guard currentPlan == nil, let family = families.first else { return }
+        let manager = DataManager(context: context)
+        _ = manager.createCurrentWeekPlan(for: family)
+        try? context.save()
     }
 }
 


### PR DESCRIPTION
## Summary
- create helper to generate a new current week plan
- expose calendar helper for week start date
- auto-create a current week plan when opening WeeklyPlannerContainerView
- show loading indicator until the plan is ready

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme FamilyPlanPro -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7b3a7288832d8757a114a85e8def