### PR TITLE
Fix weekly plan detection

### DIFF
--- a/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
+++ b/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
@@ -7,8 +7,10 @@ struct WeeklyPlannerContainerView: View {
     @Query private var families: [Family]
 
     private var currentPlan: WeeklyPlan? {
-        let calendar = Calendar.current
-        return plans.first { calendar.isDate($0.startDate, equalTo: Date(), toGranularity: .weekOfYear) }
+        var calendar = Calendar.current
+        calendar.firstWeekday = 1 // Sunday to match startOfWeek(for:)
+        let startOfThisWeek = calendar.startOfWeek(for: Date())
+        return plans.first { calendar.isDate($0.startDate, equalTo: startOfThisWeek, toGranularity: .day) }
     }
 
     var body: some View {

--- a/FamilyPlanProTests/WorkflowTests.swift
+++ b/FamilyPlanProTests/WorkflowTests.swift
@@ -85,4 +85,17 @@ final class WorkflowTests: XCTestCase {
         XCTAssertEqual(plan.status, .conflict)
         XCTAssertEqual(plan.lastModifiedByUserID, userA.name)
     }
+
+    func testCurrentPlanLookup() throws {
+        var calendar = Calendar.current
+        calendar.firstWeekday = 1
+        let startOfWeek = calendar.startOfWeek(for: Date())
+        let plan = WeeklyPlan(startDate: startOfWeek)
+        let plans = [plan]
+
+        calendar.firstWeekday = 1
+        let startOfThisWeek = calendar.startOfWeek(for: Date())
+        let found = plans.first { calendar.isDate($0.startDate, equalTo: startOfThisWeek, toGranularity: .day) }
+        XCTAssertNotNil(found)
+    }
 }


### PR DESCRIPTION
## Summary
- fix start-of-week calculation so a new plan is detected
- add test covering current week plan lookup

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d95199548832dad73eca7b9799ef9