### PR TITLE
Improve onboarding when no family exists

### DIFF
--- a/FamilyPlanPro/Views/AddFamilyView.swift
+++ b/FamilyPlanPro/Views/AddFamilyView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+import SwiftData
+
+struct AddFamilyView: View {
+    @Environment(\.modelContext) private var context
+    @State private var name: String = ""
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Create a Family")
+                .font(.title)
+            TextField("Family Name", text: $name)
+                .textFieldStyle(.roundedBorder)
+            Button("Create") {
+                guard !name.isEmpty else { return }
+                let manager = DataManager(context: context)
+                _ = manager.createFamily(name: name)
+                try? context.save()
+                name = ""
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    AddFamilyView()
+        .modelContainer(for: Family.self, inMemory: true)
+}

--- a/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
+++ b/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
@@ -15,7 +15,9 @@ struct WeeklyPlannerContainerView: View {
 
     var body: some View {
         Group {
-            if let plan = currentPlan {
+            if families.isEmpty {
+                AddFamilyView()
+            } else if let plan = currentPlan {
                 switch plan.status {
                 case .suggestionMode:
                     SuggestionView(plan: plan)

--- a/FamilyPlanProUITests/FamilyPlanProUITests.swift
+++ b/FamilyPlanProUITests/FamilyPlanProUITests.swift
@@ -25,6 +25,7 @@ final class FamilyPlanProUITests: XCTestCase {
     @MainActor
     func testPlannerDisplaysSuggestionView() throws {
         let app = XCUIApplication()
+        app.launchEnvironment["UITEST_STATUS"] = "suggestionMode"
         app.launch()
         XCTAssertTrue(app.navigationBars["Suggestions"].exists)
     }
@@ -43,6 +44,13 @@ final class FamilyPlanProUITests: XCTestCase {
         app.launchEnvironment["UITEST_STATUS"] = "finalized"
         app.launch()
         XCTAssertTrue(app.navigationBars["Finalized"].exists)
+    }
+
+    @MainActor
+    func testShowsAddFamilyViewWhenEmpty() throws {
+        let app = XCUIApplication()
+        app.launch()
+        XCTAssertTrue(app.staticTexts["Create a Family"].exists)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- add an `AddFamilyView` for creating a first Family
- show `AddFamilyView` when no families exist instead of an endless spinner
- update UI tests for the new behavior

## Testing
- `xcodebuild test -project FamilyPlanPro.xcodeproj -scheme FamilyPlanPro -destination 'platform=iOS Simulator,name=iPhone 14' | head -n 20` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b1d85b9c832d879bc24d863236b1