### PR TITLE
Fix create family flow and add UI test

### DIFF
--- a/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
+++ b/FamilyPlanPro/Views/WeeklyPlannerContainerView.swift
@@ -42,6 +42,9 @@ struct WeeklyPlannerContainerView: View {
             }
         }
         .onAppear(perform: createWeekIfNeeded)
+        .onChange(of: families.count) { _, _ in
+            createWeekIfNeeded()
+        }
         .sheet(isPresented: $showingAddFamily) {
             NavigationStack { AddFamilyView() }
         }

--- a/FamilyPlanProUITests/FamilyPlanProUITests.swift
+++ b/FamilyPlanProUITests/FamilyPlanProUITests.swift
@@ -54,6 +54,19 @@ final class FamilyPlanProUITests: XCTestCase {
     }
 
     @MainActor
+    func testCreateFamilyGeneratesPlan() throws {
+        let app = XCUIApplication()
+        app.launch()
+        let field = app.textFields["Family Name"]
+        XCTAssertTrue(field.waitForExistence(timeout: 1))
+        field.tap()
+        field.typeText("Test")
+        app.buttons["Create"].tap()
+        let suggestions = app.navigationBars["Suggestions"]
+        XCTAssertTrue(suggestions.waitForExistence(timeout: 2))
+    }
+
+    @MainActor
     func testLaunchPerformance() throws {
         // This measures how long it takes to launch your application.
         measure(metrics: [XCTApplicationLaunchMetric()]) {


### PR DESCRIPTION
## Summary
- create a weekly plan whenever families array changes
- ensure onboarding flow transitions to Suggestions view
- add UI test covering family creation flow

## Testing
- `xcodebuild test -project FamilyPlanPro.xcodeproj -scheme FamilyPlanPro -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aee547ff8832dabf9730caee2d09b