### PR TITLE
Implement review slot view and rejection workflow

### DIFF
--- a/FamilyPlanPro/DataManager.swift
+++ b/FamilyPlanPro/DataManager.swift
@@ -71,6 +71,7 @@ final class DataManager {
     func rejectPendingSuggestion(in slot: MealSlot,
                                  newTitle: String,
                                  by user: User?,
+                                 reason: String? = nil,
                                  in plan: WeeklyPlan) -> MealSuggestion {
         if let lastUserID = plan.lastModifiedByUserID,
            let rejectingUser = user,
@@ -78,7 +79,10 @@ final class DataManager {
             plan.status = .conflict
         }
 
-        let suggestion = MealSuggestion(title: newTitle, user: user, slot: slot)
+        let suggestion = MealSuggestion(title: newTitle,
+                                        user: user,
+                                        slot: slot,
+                                        reason: reason)
         slot.pendingSuggestion = suggestion
         plan.lastModifiedByUserID = user?.name
         context.insert(suggestion)

--- a/FamilyPlanPro/FamilyPlanProApp.swift
+++ b/FamilyPlanPro/FamilyPlanProApp.swift
@@ -59,8 +59,8 @@ struct FamilyPlanProApp: App {
             manager.finalizeIfPossible(plan)
         case .conflict:
             manager.submitPlanForReview(plan, by: userA)
-            _ = manager.rejectPendingSuggestion(in: slot, newTitle: "Alt", by: userB, in: plan)
-            _ = manager.rejectPendingSuggestion(in: slot, newTitle: "Alt2", by: userA, in: plan)
+            _ = manager.rejectPendingSuggestion(in: slot, newTitle: "Alt", by: userB, reason: nil, in: plan)
+            _ = manager.rejectPendingSuggestion(in: slot, newTitle: "Alt2", by: userA, reason: nil, in: plan)
         case .suggestionMode:
             break
         }

--- a/FamilyPlanPro/Models.swift
+++ b/FamilyPlanPro/Models.swift
@@ -71,11 +71,13 @@ final class MealSlot {
 @Model
 final class MealSuggestion {
     var title: String
+    var reason: String?
     weak var user: User?
     weak var slot: MealSlot?
 
-    init(title: String, user: User? = nil, slot: MealSlot? = nil) {
+    init(title: String, user: User? = nil, slot: MealSlot? = nil, reason: String? = nil) {
         self.title = title
+        self.reason = reason
         self.user = user
         self.slot = slot
     }

--- a/FamilyPlanPro/Views/MealSlotReviewView.swift
+++ b/FamilyPlanPro/Views/MealSlotReviewView.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+import SwiftData
+import Observation
+
+struct MealSlotReviewView: View {
+    @Environment(\.modelContext) private var context
+    @Bindable var slot: MealSlot
+    @Bindable var plan: WeeklyPlan
+    var users: [User]
+
+    @State private var showRejectSheet = false
+    @State private var newTitle: String = ""
+    @State private var selectedUser: User?
+    @State private var reason: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("\(slot.date, format: Date.FormatStyle(date: .numeric, time: .omitted)) \(slot.mealType.rawValue.capitalized)")
+                .font(.headline)
+            if let pending = slot.pendingSuggestion {
+                Text(pending.title)
+                if let user = pending.user {
+                    Text("Responsible: \(user.name)")
+                        .font(.caption)
+                }
+                HStack {
+                    Button("Accept") {
+                        let manager = DataManager(context: context)
+                        manager.acceptPendingSuggestion(in: slot)
+                        manager.finalizeIfPossible(plan)
+                        try? context.save()
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button("Reject") {
+                        newTitle = pending.title
+                        selectedUser = pending.user
+                        showRejectSheet = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+        }
+        .sheet(isPresented: $showRejectSheet) {
+            NavigationStack {
+                Form {
+                    Section("New Suggestion") {
+                        TextField("Meal name", text: $newTitle)
+                        Picker("Responsible", selection: $selectedUser) {
+                            Text("Unassigned").tag(Optional<User>(nil))
+                            ForEach(users) { user in
+                                Text(user.name).tag(Optional(user))
+                            }
+                        }
+                        TextField("Reason (optional)", text: $reason)
+                    }
+                    Button("Submit") {
+                        let manager = DataManager(context: context)
+                        _ = manager.rejectPendingSuggestion(in: slot,
+                                                           newTitle: newTitle,
+                                                           by: selectedUser,
+                                                           reason: reason.isEmpty ? nil : reason,
+                                                           in: plan)
+                        try? context.save()
+                        newTitle = ""
+                        selectedUser = nil
+                        reason = ""
+                        showRejectSheet = false
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .navigationTitle("Replace Suggestion")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { showRejectSheet = false }
+                    }
+                }
+            }
+        }
+        .padding(.vertical)
+    }
+}
+
+struct MealSlotReviewView_Previews: PreviewProvider {
+    static var previews: some View {
+        let schema = Schema([
+            Family.self,
+            WeeklyPlan.self,
+            MealSlot.self,
+            MealSuggestion.self,
+        ])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: schema, configurations: [config])
+        let manager = DataManager(context: container.mainContext)
+        let family = manager.createFamily(name: "Preview")
+        let userA = manager.addUser(name: "Alice", to: family)
+        let plan = manager.createWeeklyPlan(startDate: .now, for: family)
+        let slot = manager.addMealSlot(date: .now, type: .breakfast, to: plan)
+        _ = manager.setPendingSuggestion(title: "Eggs", user: userA, for: slot)
+        try? container.mainContext.save()
+
+        return MealSlotReviewView(slot: slot, plan: plan, users: family.users)
+            .modelContainer(container)
+    }
+}
+

--- a/FamilyPlanPro/Views/ReviewView.swift
+++ b/FamilyPlanPro/Views/ReviewView.swift
@@ -9,30 +9,8 @@ struct ReviewView: View {
     var body: some View {
         List {
             ForEach(plan.slots) { slot in
-                if let pending = slot.pendingSuggestion {
-                    VStack(alignment: .leading) {
-                        Text("\(slot.date, format: Date.FormatStyle(date: .numeric, time: .omitted)) \(slot.mealType.rawValue.capitalized)")
-                            .font(.headline)
-                        Text(pending.title)
-                        HStack {
-                            Button("Accept") {
-                                let manager = DataManager(context: context)
-                                manager.acceptPendingSuggestion(in: slot)
-                                manager.finalizeIfPossible(plan)
-                                try? context.save()
-                            }
-                            .buttonStyle(.bordered)
-                            Button("Reject") {
-                                let manager = DataManager(context: context)
-                                _ = manager.rejectPendingSuggestion(in: slot,
-                                                                   newTitle: pending.title,
-                                                                   by: plan.family?.users.last,
-                                                                   in: plan)
-                                try? context.save()
-                            }
-                            .buttonStyle(.borderedProminent)
-                        }
-                    }
+                if slot.pendingSuggestion != nil {
+                    MealSlotReviewView(slot: slot, plan: plan, users: plan.family?.users ?? [])
                 }
             }
         }

--- a/FamilyPlanProTests/WorkflowTests.swift
+++ b/FamilyPlanProTests/WorkflowTests.swift
@@ -52,7 +52,7 @@ final class WorkflowTests: XCTestCase {
         try manager.save()
 
         manager.submitPlanForReview(plan, by: userA)
-        _ = manager.rejectPendingSuggestion(in: slot, newTitle: "Bagel", by: userB, in: plan)
+        _ = manager.rejectPendingSuggestion(in: slot, newTitle: "Bagel", by: userB, reason: nil, in: plan)
 
         XCTAssertEqual(plan.status, .reviewMode)
         XCTAssertEqual(plan.lastModifiedByUserID, userB.name)
@@ -78,9 +78,9 @@ final class WorkflowTests: XCTestCase {
         try manager.save()
 
         manager.submitPlanForReview(plan, by: userA)
-        _ = manager.rejectPendingSuggestion(in: slot, newTitle: "Bagel", by: userB, in: plan)
+        _ = manager.rejectPendingSuggestion(in: slot, newTitle: "Bagel", by: userB, reason: nil, in: plan)
 
-        _ = manager.rejectPendingSuggestion(in: slot, newTitle: "Cereal", by: userA, in: plan)
+        _ = manager.rejectPendingSuggestion(in: slot, newTitle: "Cereal", by: userA, reason: nil, in: plan)
 
         XCTAssertEqual(plan.status, .conflict)
         XCTAssertEqual(plan.lastModifiedByUserID, userA.name)


### PR DESCRIPTION
## Summary
- add `reason` property to `MealSuggestion`
- support reason in `DataManager.rejectPendingSuggestion`
- use the new parameter in app setup and tests
- introduce `MealSlotReviewView` with accept/reject actions
- refactor `ReviewView` to use the reusable review slot component

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686af15c573c832d91ea80f3b0f1f04a